### PR TITLE
fix: check_transfer_sol_to typo

### DIFF
--- a/programs/marinade-finance/src/state/liquid_unstake.rs
+++ b/programs/marinade-finance/src/state/liquid_unstake.rs
@@ -48,7 +48,7 @@ impl<'info> LiquidUnstake<'info> {
     }
 
     fn check_transfer_sol_to(&self) -> ProgramResult {
-        check_owner_program(&self.transfer_sol_to, &system_program::ID, "transfer_from")?;
+        check_owner_program(&self.transfer_sol_to, &system_program::ID, "transfer_sol_to")?;
         Ok(())
     }
 


### PR DESCRIPTION
Found by providing something else than a system program account for transfer_sol_to and be confused by the error