### PR TITLE
further convert program-owner-checks

### DIFF
--- a/programs/marinade-finance/src/lib.rs
+++ b/programs/marinade-finance/src/lib.rs
@@ -301,17 +301,18 @@ pub struct Initialize<'info> {
     pub state: Box<Account<'info, State>>,
 
     pub reserve_pda: SystemAccount<'info>,
-    /// CHECK: manual account processing
-    #[account(mut, rent_exempt = enforce)]
+
+    /// CHECK: Manual account data management (fixed item size list)
+    #[account(mut, rent_exempt = enforce, owner = ID)]
     pub stake_list: UncheckedAccount<'info>,
-    /// CHECK: manual account processing
-    #[account(mut, rent_exempt = enforce)]
+
+    /// CHECK: Manual account data management (fixed item size list)
+    #[account(mut, rent_exempt = enforce, owner = ID)]
     pub validator_list: UncheckedAccount<'info>,
 
     pub msol_mint: Box<Account<'info, Mint>>,
 
-    /// CHECK: not important
-    pub operational_sol_account: UncheckedAccount<'info>,
+    pub operational_sol_account: SystemAccount<'info>,
 
     pub liq_pool: LiqPoolInitialize<'info>,
 
@@ -393,8 +394,7 @@ pub struct AddLiquidity<'info> {
     #[account(owner = system_program::ID)]
     pub transfer_from: Signer<'info>,
 
-    // #[check_owner_program("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")]
-    #[account(mut)] // , owner = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")]
+    #[account(mut)]
     pub mint_to: Box<Account<'info, TokenAccount>>,
 
     pub system_program: Program<'info, System>,
@@ -480,7 +480,7 @@ pub struct DepositStakeAccount<'info> {
     #[account(mut)]
     pub stake_account: Box<Account<'info, StakeAccount>>,
     pub stake_authority: Signer<'info>,
-    /// CHECK: manual account processing
+    /// CHECK: manual account processing, only required if adding validator (if allowed)
     #[account(mut)]
     pub duplication_flag: UncheckedAccount<'info>,
     #[account(mut)]
@@ -543,9 +543,9 @@ pub struct AddValidator<'info> {
 
     /// CHECK: todo
     pub validator_vote: UncheckedAccount<'info>,
-    /// CHECK: manual account processing
+    
     #[account(mut)]
-    pub duplication_flag: UncheckedAccount<'info>,
+    pub duplication_flag: SystemAccount<'info>,
     #[account(mut)]
     #[account(owner = system_program::ID)]
     pub rent_payer: Signer<'info>,

--- a/programs/marinade-finance/src/lib.rs
+++ b/programs/marinade-finance/src/lib.rs
@@ -373,7 +373,7 @@ pub struct AddLiquidity<'info> {
     #[account(mut)]
     pub state: Box<Account<'info, State>>,
 
-    #[account(mut)]
+    #[account(mut, constraint = lp_mint.key() == state.liq_pool.lp_mint)]
     pub lp_mint: Box<Account<'info, Mint>>,
 
     /// CHECK: PDA
@@ -406,7 +406,7 @@ pub struct RemoveLiquidity<'info> {
     #[account(mut)]
     pub state: Box<Account<'info, State>>,
 
-    #[account(mut)]
+    #[account(mut, constraint = {lp_mint.key() == state.liq_pool.lp_mint})]
     pub lp_mint: Box<Account<'info, Mint>>,
 
     #[account(mut)]

--- a/programs/marinade-finance/src/liq_pool.rs
+++ b/programs/marinade-finance/src/liq_pool.rs
@@ -64,10 +64,6 @@ impl LiqPool {
         Pubkey::create_with_seed(state, Self::MSOL_LEG_SEED, &spl_token::ID).unwrap()
     }
 
-    pub fn check_lp_mint(&mut self, lp_mint: &Pubkey) -> Result<()> {
-        check_address(lp_mint, &self.lp_mint, "lp_mint")
-    }
-
     pub fn check_liq_pool_msol_leg(&self, liq_pool_msol_leg: &Pubkey) -> Result<()> {
         check_address(liq_pool_msol_leg, &self.msol_leg, "liq_pool_msol_leg")
     }

--- a/programs/marinade-finance/src/liq_pool/add_liquidity.rs
+++ b/programs/marinade-finance/src/liq_pool/add_liquidity.rs
@@ -8,7 +8,6 @@ use anchor_spl::token::{mint_to, MintTo, spl_token};
 
 impl<'info> AddLiquidity<'info> {
     fn check_transfer_from(&self, lamports: u64) -> Result<()> {
-        check_owner_program(&self.transfer_from, &system_program::ID, "transfer_from")?;
         if self.transfer_from.lamports() < lamports {
             msg!(
                 "{} balance is {} but expected {}",

--- a/programs/marinade-finance/src/liq_pool/add_liquidity.rs
+++ b/programs/marinade-finance/src/liq_pool/add_liquidity.rs
@@ -30,9 +30,6 @@ impl<'info> AddLiquidity<'info> {
         msg!("add-liq pre check");
         check_min_amount(lamports, self.state.min_deposit, "add_liquidity")?;
         self.state
-            .liq_pool
-            .check_lp_mint(self.lp_mint.to_account_info().key)?;
-        self.state
             .check_lp_mint_authority(self.lp_mint_authority.key)?;
         // self.state
         //     .check_msol_mint(self.msol_mint.to_account_info().key)?;

--- a/programs/marinade-finance/src/liq_pool/remove_liquidity.rs
+++ b/programs/marinade-finance/src/liq_pool/remove_liquidity.rs
@@ -57,9 +57,6 @@ impl<'info> RemoveLiquidity<'info> {
 
     pub fn process(&mut self, tokens: u64) -> Result<()> {
         msg!("rem-liq pre check");
-        self.state
-            .liq_pool
-            .check_lp_mint(self.lp_mint.to_account_info().key)?;
         // self.state
         //     .check_msol_mint(self.msol_mint.to_account_info().key)?;
         self.check_burn_from(tokens)?;

--- a/programs/marinade-finance/src/state/deposit.rs
+++ b/programs/marinade-finance/src/state/deposit.rs
@@ -3,7 +3,7 @@ use anchor_lang::solana_program::{program::invoke, system_instruction, system_pr
 use anchor_spl::token::{mint_to, transfer, MintTo, Transfer, spl_token};
 
 use crate::{
-    checks::{check_address, check_min_amount, check_owner_program, check_token_mint},
+    checks::{check_address, check_min_amount, check_token_mint},
     liq_pool::LiqPoolHelpers,
     state::StateHelpers,
     Deposit,
@@ -11,7 +11,6 @@ use crate::{
 
 impl<'info> Deposit<'info> {
     fn check_transfer_from(&self, lamports: u64) -> Result<()> {
-        check_owner_program(&self.transfer_from, &system_program::ID, "transfer_from")?;
         if self.transfer_from.lamports() < lamports {
             return Err(Error::from(ProgramError::InsufficientFunds).with_source(source!()));
         }

--- a/programs/marinade-finance/src/state/initialize.rs
+++ b/programs/marinade-finance/src/state/initialize.rs
@@ -1,14 +1,14 @@
 use crate::{
     checks::{
         check_address, check_freeze_authority, check_mint_authority, check_mint_empty,
-        check_owner_program, check_token_mint,
+        check_token_mint,
     },
     stake_system::StakeSystem,
     validator_system::ValidatorSystem,
-    Initialize, InitializeData, LiqPoolInitialize, ID, MAX_REWARD_FEE,
+    Initialize, InitializeData, LiqPoolInitialize, MAX_REWARD_FEE,
 };
 use anchor_lang::prelude::*;
-use anchor_lang::solana_program::{program_pack::Pack, system_program};
+use anchor_lang::solana_program::{program_pack::Pack};
 use anchor_spl::token::spl_token;
 
 use super::State;
@@ -85,13 +85,6 @@ impl<'info> Initialize<'info> {
         self.check_reserve_pda()?;
         self.check_msol_mint()?;
         self.check_treasury_accounts()?;
-        check_owner_program(
-            &self.operational_sol_account,
-            &system_program::ID,
-            "operational_sol",
-        )?;
-        check_owner_program(&self.stake_list, &ID, "stake_list")?;
-        check_owner_program(&self.validator_list, &ID, "validator_list")?;
 
         self.state.msol_mint = *self.msol_mint.to_account_info().key;
         self.state.admin_authority = data.admin_authority;

--- a/programs/marinade-finance/src/validator_system/add.rs
+++ b/programs/marinade-finance/src/validator_system/add.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program::{program::invoke_signed, system_instruction, system_program};
 
 use crate::{
-    checks::{check_address, check_owner_program},
+    checks::{check_address},
     AddValidator, ID,
 };
 //use super::{ValidatorRecord, ValidatorSystem};
@@ -15,12 +15,6 @@ impl<'info> AddValidator<'info> {
         self.state
             .validator_system
             .check_validator_list(&self.validator_list)?;
-        check_owner_program(
-            &self.duplication_flag,
-            &system_program::ID,
-            "duplication_flag",
-        )?;
-        check_owner_program(&self.rent_payer, &system_program::ID, "rent_payer")?;
         if !self.rent.is_exempt(self.rent_payer.lamports(), 0) {
             msg!(
                 "Rent payer must have at least {} lamports",


### PR DESCRIPTION
note: 3 uses of fn check_owner_program remain, but removing those is not a refactor, and requires more review