### PR TITLE
Fix compilation with no-entrypoint feature

### DIFF
--- a/programs/marinade-finance/src/lib.rs
+++ b/programs/marinade-finance/src/lib.rs
@@ -13,6 +13,7 @@ pub mod state;
 
 use instructions::*;
 
+#[cfg(not(feature = "no-entrypoint"))]
 use solana_security_txt::security_txt;
 pub use state::State;
 

--- a/programs/marinade-finance/src/state/fee.rs
+++ b/programs/marinade-finance/src/state/fee.rs
@@ -50,7 +50,7 @@ impl TryFrom<f64> for Fee {
         let basis_points =
             u32::try_from(basis_points_i).map_err(|_| MarinadeError::CalculationFailure)?;
         let fee = Fee::from_basis_points(basis_points);
-        fee.check(source!())?;
+        fee.check()?;
         Ok(fee)
     }
 }


### PR DESCRIPTION
The build fails with `no-etrypoint` feature used `anchor build -- --features no-entrypoint`. Fix for that.