### PR TITLE
bugfix: overflow error in the `total_lamports_under_control`

### DIFF
--- a/programs/marinade-finance/src/calc.rs
+++ b/programs/marinade-finance/src/calc.rs
@@ -8,23 +8,23 @@ use std::convert::TryFrom;
 /// as value  = shares * share_price where share_price=total_value/total_shares
 /// or shares = amount_value / share_price where share_price=total_value/total_shares
 ///     => shares = amount_value * 1/share_price where 1/share_price=total_shares/total_value
-pub fn proportional(amount: u64, numerator: u64, denominator: u64) -> Result<u64> {
+pub fn proportional(amount: u128, numerator: u128, denominator: u128) -> Result<u64> {
     if denominator == 0 {
-        return Ok(amount);
+        return Ok(amount as u64);
     }
     u64::try_from((amount as u128) * (numerator as u128) / (denominator as u128))
         .map_err(|_| error!(MarinadeError::CalculationFailure))
 }
 
 #[inline] //alias for proportional
-pub fn value_from_shares(shares: u64, total_value: u64, total_shares: u64) -> Result<u64> {
+pub fn value_from_shares(shares: u128, total_value: u128, total_shares: u128) -> Result<u64> {
     proportional(shares, total_value, total_shares)
 }
 
-pub fn shares_from_value(value: u64, total_value: u64, total_shares: u64) -> Result<u64> {
+pub fn shares_from_value(value: u128, total_value: u128, total_shares: u128) -> Result<u64> {
     if total_shares == 0 {
         //no shares minted yet / First mint
-        Ok(value)
+        Ok(value as u64)
     } else {
         proportional(value, total_shares, total_value)
     }

--- a/programs/marinade-finance/src/events/crank.rs
+++ b/programs/marinade-finance/src/events/crank.rs
@@ -105,7 +105,7 @@ pub struct UpdateActiveEvent {
     pub msol_price_change: U64ValueChange,
     pub reward_fee_used: Fee,
     // MSOL price used
-    pub total_virtual_staked_lamports: u64,
+    pub total_virtual_staked_lamports: u128,
     pub msol_supply: u64,
 }
 
@@ -122,6 +122,6 @@ pub struct UpdateDeactivatedEvent {
     pub reward_fee_used: Fee,
     pub operational_sol_balance: u64,
     // MSOL price used
-    pub total_virtual_staked_lamports: u64,
+    pub total_virtual_staked_lamports: u128,
     pub msol_supply: u64,
 }

--- a/programs/marinade-finance/src/events/delayed_unstake.rs
+++ b/programs/marinade-finance/src/events/delayed_unstake.rs
@@ -26,6 +26,6 @@ pub struct OrderUnstakeEvent {
     pub sol_amount: u64,
     pub fee_bp_cents: u32,
     // MSOL price used
-    pub total_virtual_staked_lamports: u64,
+    pub total_virtual_staked_lamports: u128,
     pub msol_supply: u64,
 }

--- a/programs/marinade-finance/src/events/liq_pool.rs
+++ b/programs/marinade-finance/src/events/liq_pool.rs
@@ -13,7 +13,7 @@ pub struct AddLiquidityEvent {
     pub sol_added_amount: u64,
     pub lp_minted: u64,
     // MSOL price used
-    pub total_virtual_staked_lamports: u64,
+    pub total_virtual_staked_lamports: u128,
     pub msol_supply: u64,
 }
 

--- a/programs/marinade-finance/src/events/user.rs
+++ b/programs/marinade-finance/src/events/user.rs
@@ -14,7 +14,7 @@ pub struct DepositStakeAccountEvent {
     pub user_msol_balance: u64,
     pub msol_minted: u64,
     // MSOL price used
-    pub total_virtual_staked_lamports: u64,
+    pub total_virtual_staked_lamports: u128,
     pub msol_supply: u64,
 }
 
@@ -32,7 +32,7 @@ pub struct DepositEvent {
     pub sol_deposited: u64,
     pub msol_minted: u64,
     // MSOL price used
-    pub total_virtual_staked_lamports: u64,
+    pub total_virtual_staked_lamports: u128,
     pub msol_supply: u64,
 }
 
@@ -54,6 +54,6 @@ pub struct WithdrawStakeAccountEvent {
     pub split_lamports: u64,
     pub fee_bp_cents: u32,
     // MSOL price used
-    pub total_virtual_staked_lamports: u64,
+    pub total_virtual_staked_lamports: u128,
     pub msol_supply: u64,
 }

--- a/programs/marinade-finance/src/instructions/crank/update.rs
+++ b/programs/marinade-finance/src/instructions/crank/update.rs
@@ -249,7 +249,7 @@ impl<'info> UpdateCommon<'info> {
     // returns fees in msol
     pub fn mint_protocol_fees(&mut self, lamports_incoming: u64) -> Result<u64> {
         // apply x% protocol fee on staking rewards (do this before updating validators' balance, so it's 1% at old, lower, price)
-        let protocol_rewards_fee = self.state.reward_fee.apply(lamports_incoming);
+        let protocol_rewards_fee = self.state.reward_fee.apply(lamports_incoming as u128);
         msg!("protocol_rewards_fee {}", protocol_rewards_fee);
         // compute mSOL amount for protocol_rewards_fee
         let fee_as_msol_amount = self.state.calc_msol_from_lamports(protocol_rewards_fee)?;

--- a/programs/marinade-finance/src/instructions/delayed_unstake/order_unstake.rs
+++ b/programs/marinade-finance/src/instructions/delayed_unstake/order_unstake.rs
@@ -61,7 +61,7 @@ impl<'info> OrderUnstake<'info> {
         let delay_unstake_fee_lamports = self
             .state
             .delayed_unstake_fee
-            .apply(sol_value_of_msol_burned);
+            .apply(sol_value_of_msol_burned as u128);
         // the fee value will be burned but not delivered, thus increasing mSOL value slightly for all mSOL holders
         let lamports_for_user = sol_value_of_msol_burned - delay_unstake_fee_lamports;
 

--- a/programs/marinade-finance/src/instructions/liq_pool/add_liquidity.rs
+++ b/programs/marinade-finance/src/instructions/liq_pool/add_liquidity.rs
@@ -111,7 +111,7 @@ impl<'info> AddLiquidity<'info> {
         );
 
         let lp_supply = self.state.liq_pool.lp_supply;
-        let shares_for_user = shares_from_value(lamports, total_liq_pool_value, lp_supply)?;
+        let shares_for_user = shares_from_value(lamports as u128, total_liq_pool_value as u128, lp_supply as u128)?;
 
         msg!("LP for user {}", shares_for_user);
 

--- a/programs/marinade-finance/src/instructions/liq_pool/liquid_unstake.rs
+++ b/programs/marinade-finance/src/instructions/liq_pool/liquid_unstake.rs
@@ -88,7 +88,7 @@ impl<'info> LiquidUnstake<'info> {
         };
 
         // compute fee in msol
-        let msol_fee = liquid_unstake_fee.apply(msol_amount);
+        let msol_fee = liquid_unstake_fee.apply(msol_amount as u128);
         msg!("msol_fee {}", msol_fee);
 
         // fee goes into treasury & LPs, so the user receives lamport value of data.msol_amount - msol_fee
@@ -129,7 +129,7 @@ impl<'info> LiquidUnstake<'info> {
 
         // cut 25% from the fee for the treasury
         let treasury_msol_cut = if treasury_msol_balance.is_some() {
-            self.state.liq_pool.treasury_cut.apply(msol_fee)
+            self.state.liq_pool.treasury_cut.apply(msol_fee as u128)
         } else {
             0
         };

--- a/programs/marinade-finance/src/instructions/liq_pool/remove_liquidity.rs
+++ b/programs/marinade-finance/src/instructions/liq_pool/remove_liquidity.rs
@@ -90,14 +90,14 @@ impl<'info> RemoveLiquidity<'info> {
         msg!("mSOL-SOL-LP total supply:{}", lp_mint_supply);
 
         let sol_out_amount = proportional(
-            tokens,
-            sol_leg_balance - self.state.rent_exempt_for_token_acc,
-            self.state.liq_pool.lp_supply, // Use virtual amount
+            tokens as u128,
+            (sol_leg_balance - self.state.rent_exempt_for_token_acc) as u128,
+            self.state.liq_pool.lp_supply as u128, // Use virtual amount
         )?;
         let msol_out_amount = proportional(
-            tokens,
-            msol_leg_balance,
-            self.state.liq_pool.lp_supply, // Use virtual amount
+            tokens as u128,
+            msol_leg_balance as u128,
+            self.state.liq_pool.lp_supply as u128, // Use virtual amount
         )?;
 
         require_gte!(

--- a/programs/marinade-finance/src/instructions/user/withdraw_stake_account.rs
+++ b/programs/marinade-finance/src/instructions/user/withdraw_stake_account.rs
@@ -174,7 +174,7 @@ impl<'info> WithdrawStakeAccount<'info> {
             // apply withdraw_stake_account_fee to avoid economical attacks
             // withdraw_stake_account_fee must be >= one epoch staking rewards
             let withdraw_stake_account_fee_lamports =
-                self.state.withdraw_stake_account_fee.apply(sol_value);
+                self.state.withdraw_stake_account_fee.apply(sol_value as u128);
             // The mSOL fee value is sending to the treasury but
             // the corresponding SOL value is not delivering inside the stake to the user
             // because it is a fee user is paying for running this instruction

--- a/programs/marinade-finance/src/state/fee.rs
+++ b/programs/marinade-finance/src/state/fee.rs
@@ -40,9 +40,9 @@ impl Fee {
         Ok(())
     }
 
-    pub fn apply(&self, lamports: u64) -> u64 {
+    pub fn apply(&self, lamports: u128) -> u64 {
         // LMT no error possible
-        (lamports as u128 * self.basis_points as u128 / Self::MAX_BASIS_POINTS as u128) as u64
+        (lamports * self.basis_points as u128 / Self::MAX_BASIS_POINTS as u128) as u64
     }
 }
 
@@ -106,9 +106,9 @@ impl FeeCents {
         Ok(())
     }
 
-    pub fn apply(&self, lamports: u64) -> u64 {
+    pub fn apply(&self, lamports: u128) -> u64 {
         // LMT no error possible
-        (lamports as u128 * self.bp_cents as u128 / Self::MAX_BP_CENTS.bp_cents as u128) as u64
+        (lamports * self.bp_cents as u128 / Self::MAX_BP_CENTS.bp_cents as u128) as u64
     }
 }
 

--- a/programs/marinade-finance/src/state/liq_pool.rs
+++ b/programs/marinade-finance/src/state/liq_pool.rs
@@ -70,7 +70,7 @@ impl LiqPool {
         } else {
             Fee {
                 basis_points: self.lp_max_fee.basis_points
-                    - proportional(self.delta() as u64, lamports, self.lp_liquidity_target).unwrap()
+                    - proportional(self.delta() as u128, lamports as u128, self.lp_liquidity_target as u128).unwrap()
                         as u32,
             }
         }

--- a/programs/marinade-finance/src/state/mod.rs
+++ b/programs/marinade-finance/src/state/mod.rs
@@ -187,43 +187,43 @@ impl State {
     }
 
     /// total_active_balance + total_cooling_down + available_reserve_balance
-    pub fn total_lamports_under_control(&self) -> u64 {
-        self.validator_system.total_active_balance
-            + self.total_cooling_down()
-            + self.available_reserve_balance // reserve_pda.lamports() - self.rent_exempt_for_token_acc
+    pub fn total_lamports_under_control(&self) -> u128 {
+        self.validator_system.total_active_balance as u128
+            + self.total_cooling_down() as u128
+            + self.available_reserve_balance as u128 // reserve_pda.lamports() - self.rent_exempt_for_token_acc
     }
 
     pub fn check_staking_cap(&self, transfering_lamports: u64) -> Result<()> {
-        let result_amount = self.total_lamports_under_control() + transfering_lamports;
+        let result_amount = self.total_lamports_under_control() + transfering_lamports as u128;
         require_lte!(
             result_amount,
-            self.staking_sol_cap,
+            self.staking_sol_cap as u128,
             MarinadeError::StakingIsCapped
         );
         Ok(())
     }
 
-    pub fn total_virtual_staked_lamports(&self) -> u64 {
+    pub fn total_virtual_staked_lamports(&self) -> u128 {
         // if we get slashed it may be negative but we must use 0 instead
         self.total_lamports_under_control()
-            .saturating_sub(self.circulating_ticket_balance) //tickets created -> cooling down lamports or lamports already in reserve and not claimed yet
+            .saturating_sub(self.circulating_ticket_balance as u128) //tickets created -> cooling down lamports or lamports already in reserve and not claimed yet
     }
 
     /// calculate the amount of msol tokens corresponding to certain lamport amount
     pub fn calc_msol_from_lamports(&self, stake_lamports: u64) -> Result<u64> {
         shares_from_value(
-            stake_lamports,
+            stake_lamports as u128,
             self.total_virtual_staked_lamports(),
-            self.msol_supply,
+            self.msol_supply as u128,
         )
     }
     /// calculate lamports value from some msol_amount
     /// result_lamports = msol_amount * msol_price
     pub fn msol_to_sol(&self, msol_amount: u64) -> Result<u64> {
         value_from_shares(
-            msol_amount,
+            msol_amount as u128,
             self.total_virtual_staked_lamports(),
-            self.msol_supply,
+            self.msol_supply as u128,
         )
     }
 

--- a/programs/marinade-finance/src/state/validator_system.rs
+++ b/programs/marinade-finance/src/state/validator_system.rs
@@ -268,9 +268,9 @@ impl ValidatorSystem {
             return Ok(0);
         }
         proportional(
-            total_stake_target,
-            validator.score as u64,
-            self.total_validator_score as u64,
+            total_stake_target as u128,
+            validator.score as u128,
+            self.total_validator_score as u128,
         )
     }
 }


### PR DESCRIPTION
The `total_larmports_under_control` causes the error like `attempt to add with overflow` when the related values are as follows:
```
> Program log: oracle_state.validator_system.total_active_balance: 42868812732159474
> Program log: oracle_state.total_cooling_down: 18446744073709551615
> Program log: oracle_state.available_reserve_balance: 18446744073709551615
> Program log: total_lamports_under_control: 36936356960151262704
> Program log: total_virtual_staked_lamports: 36936356960151261566
```
So the arguments got changed into u128 to deal with the error. 