### PR TITLE
[GEN-8772] Clear the marinade-finance unlicensed finding in downstream cargo-deny

### DIFF
--- a/programs/marinade-finance/Cargo.toml
+++ b/programs/marinade-finance/Cargo.toml
@@ -3,6 +3,7 @@ name = "marinade-finance"
 version = "0.1.0"
 description = "Liquid Staking for the Solana Blockchain - Anchor-based on-chain program"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
Marks the `marinade-finance` crate `publish = false`, which is what `licenses.private.ignore = true` keys off; a `license` field would be wrong here because LICENSE.md is proprietary ("all rights reserved"), carries no SPDX identifier, and the crate is consumed only as a git dependency.

Measured by A/B cargo-deny 0.20.2 in copies of marcrank and validator-manager patched onto two local git sources differing only by this line, both at rev `6c1b645` — the rev both consumers actually resolve: `error[unlicensed]: marinade-finance = 0.1.0` disappears under the .github HEAD policy (marcrank 5→4 unlicensed errors, validator-manager 5→4) and under the deny.toml on .github's `claude/static-analysis-required-wrapper` branch (6→5 and 6→5). Against the deny.toml that .github `main` still serves it is a measured no-op — 7 unlicensed errors in both arms — because that copy has no `licenses.private.ignore`.

The `licenses` check still fails in both consumers afterwards — `dynsigner`, `marinade-client-rs` and `marinade-common-cli` (all from marinade-common-rs-cli) plus `solana-transaction-executor`, or `ring 0.16.20` and `webpki 0.22.4` depending on the policy — so this removes one finding, it does not turn either repo green.

⚠️ marcrank and validator-manager both pin `branch = "mainnet"`, not the default branch, so merging this to `main` does not reach them until `main` is merged into `mainnet`; and the effect only appears once a deny.toml carrying `licenses.private.ignore` is the one CI fetches.
